### PR TITLE
[Fix] missed method for copying view files

### DIFF
--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -30,6 +30,10 @@ class BeautymailServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../../views', 'beautymail');
 
+        $this->publishes([
+            __DIR__ . '/../../views' => base_path('resources/views/vendor/beautymail')
+        ]);
+
         $this->app['mailer']->getSwiftMailer()->registerPlugin(new CssInlinerPlugin());
     }
 


### PR DESCRIPTION
Fixed copying view files to the "resources/views/vendor" folder.