### PR TITLE
Update method signature to be Laravel 5.3 compatible

### DIFF
--- a/src/Snowfire/Beautymail/Beautymail.php
+++ b/src/Snowfire/Beautymail/Beautymail.php
@@ -51,7 +51,7 @@ class Beautymail implements Mailer
      *
      * @return void
      */
-    public function send($view, array $data, $callback)
+    public function send($view, array $data = [], $callback = null)
     {
         $data = array_merge($this->settings, $data);
 


### PR DESCRIPTION
Fixes https://github.com/Snowfire/Beautymail/issues/46

```
> php artisan optimize
PHP Fatal error:  Declaration of Snowfire\Beautymail\Beautymail::send() must be compatible with Illuminate\Contracts\Mail\Mailer::send($view, array $data = Array, $callback = NULL) in /.../app/vendor/snowfire/beautymail/src/Snowfire/Beautymail/Beautymail.php on line 8
                                                                                                                                                                      
  [Symfony\Component\Debug\Exception\FatalErrorException]                                                                                                             
  Declaration of Snowfire\Beautymail\Beautymail::send() must be compatible with Illuminate\Contracts\Mail\Mailer::send($view, array $data = Array, $callback = NULL)  

Script php artisan optimize handling the post-update-cmd event returned with an error
```