### PR TITLE
Make $css available for used views

### DIFF
--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -45,7 +45,7 @@ class BeautymailServiceProvider extends ServiceProvider
                 return new \Snowfire\Beautymail\Beautymail(array_merge(
                     config('beautymail.view'),
                     ['css' => implode("\n", config('beautymail.css'))]
-                );
+                )
             });
     }
 

--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -42,7 +42,10 @@ class BeautymailServiceProvider extends ServiceProvider
     {
         $this->app->singleton('Snowfire\Beautymail\Beautymail',
             function ($app) {
-                return new \Snowfire\Beautymail\Beautymail(config('beautymail.view'));
+                return new \Snowfire\Beautymail\Beautymail(array_merge(
+                    config('beautymail.view'),
+                    ['css' => implode("\n", config('beautymail.css'))]
+                );
             });
     }
 

--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -46,7 +46,7 @@ class BeautymailServiceProvider extends ServiceProvider
                     array_merge(
                         config('beautymail.view'),
                         [
-                            'css' => implode(" ", config('beautymail.css'))
+                            'css' => !is_null(config('beautymail.css')) && count(config('beautymail.css')) > 0 ? implode(" ", config('beautymail.css')) : ''
                         ]
                     )
                 );

--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -46,7 +46,7 @@ class BeautymailServiceProvider extends ServiceProvider
                     array_merge(
                         config('beautymail.view'),
                         [
-                            'css' => !is_null(config('beautymail.css')) && count(config('beautymail.css')) > 0 ? implode(" ", config('beautymail.css')) : ''
+                            'css' => ! is_null(config('beautymail.css')) && count(config('beautymail.css')) > 0 ? implode(" ", config('beautymail.css')) : '',
                         ]
                     )
                 );

--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -45,7 +45,7 @@ class BeautymailServiceProvider extends ServiceProvider
                 return new \Snowfire\Beautymail\Beautymail(array_merge(
                     config('beautymail.view'),
                     ['css' => implode("\n", config('beautymail.css'))]
-                )
+                ));
             });
     }
 

--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -46,7 +46,7 @@ class BeautymailServiceProvider extends ServiceProvider
                     array_merge(
                         config('beautymail.view'),
                         [
-                            'css' => ! is_null(config('beautymail.css')) && count(config('beautymail.css')) > 0 ? implode(" ", config('beautymail.css')) : '',
+                            'css' => ! is_null(config('beautymail.css')) && count(config('beautymail.css')) > 0 ? implode(' ', config('beautymail.css')) : '',
                         ]
                     )
                 );

--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -42,10 +42,14 @@ class BeautymailServiceProvider extends ServiceProvider
     {
         $this->app->singleton('Snowfire\Beautymail\Beautymail',
             function ($app) {
-                return new \Snowfire\Beautymail\Beautymail(array_merge(
-                    config('beautymail.view'),
-                    ['css' => implode("\n", config('beautymail.css'))]
-                ));
+                return new \Snowfire\Beautymail\Beautymail(
+                    array_merge(
+                        config('beautymail.view'),
+                        [
+                            'css' => implode(" ", config('beautymail.css'))
+                        ]
+                    )
+                );
             });
     }
 

--- a/src/views/templates/ark.blade.php
+++ b/src/views/templates/ark.blade.php
@@ -3,6 +3,9 @@
 		<title>{{ $senderName or '' }}</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/ark.css') }}</style>
+		<style type="text/css">
+			{{ $css or '' }
+		</style>
 	</head>
 	<body>
 	<table id="background-table" border="0" cellpadding="0" cellspacing="0" width="100%">

--- a/src/views/templates/ark.blade.php
+++ b/src/views/templates/ark.blade.php
@@ -3,9 +3,11 @@
 		<title>{{ $senderName or '' }}</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/ark.css') }}</style>
+		@if($css)
 		<style type="text/css">
-			{{ $css or '' }
+			{{ $css }}
 		</style>
+		@endif
 	</head>
 	<body>
 	<table id="background-table" border="0" cellpadding="0" cellspacing="0" width="100%">

--- a/src/views/templates/minty.blade.php
+++ b/src/views/templates/minty.blade.php
@@ -3,9 +3,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title></title>
 	<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/minty.css') }}</style>
-	@if($css))
+	@if($css)
 	<style type="text/css">
-		{{ $css or '' }}
+		{{ $css }}
 	</style>
 	@endif
 </head>

--- a/src/views/templates/minty.blade.php
+++ b/src/views/templates/minty.blade.php
@@ -3,9 +3,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title></title>
 	<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/minty.css') }}</style>
+	@if($css))
 	<style type="text/css">
-		{{ $css or '' }
+		{{ $css or '' }}
 	</style>
+	@endif
 </head>
 <body>
 

--- a/src/views/templates/minty.blade.php
+++ b/src/views/templates/minty.blade.php
@@ -3,6 +3,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title></title>
 	<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/minty.css') }}</style>
+	<style type="text/css">
+		{{ $css or '' }
+	</style>
 </head>
 <body>
 

--- a/src/views/templates/sunny.blade.php
+++ b/src/views/templates/sunny.blade.php
@@ -3,9 +3,9 @@
 		<title>{{ $senderName or '' }}</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/sunny.css') }}</style>
-		@if (isset($css))
-			<style>{{ $css }}</style>
-		@endif
+		<style type="text/css">
+			{{ $css or '' }
+		</style>
 	</head>
 	<body>
 	<table id="background-table" border="0" cellpadding="0" cellspacing="0" width="100%">

--- a/src/views/templates/sunny.blade.php
+++ b/src/views/templates/sunny.blade.php
@@ -3,9 +3,11 @@
 		<title>{{ $senderName or '' }}</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/sunny.css') }}</style>
+		@if($css))
 		<style type="text/css">
-			{{ $css or '' }
+			{{ $css or '' }}
 		</style>
+		@endif
 	</head>
 	<body>
 	<table id="background-table" border="0" cellpadding="0" cellspacing="0" width="100%">

--- a/src/views/templates/sunny.blade.php
+++ b/src/views/templates/sunny.blade.php
@@ -3,9 +3,9 @@
 		<title>{{ $senderName or '' }}</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<style type="text/css">{{ file_get_contents(app_path() . '/../vendor/snowfire/beautymail/src/styles/css/sunny.css') }}</style>
-		@if($css))
+		@if($css)
 		<style type="text/css">
-			{{ $css or '' }}
+			{{ $css }}
 		</style>
 		@endif
 	</head>

--- a/src/views/templates/widgets.blade.php
+++ b/src/views/templates/widgets.blade.php
@@ -91,6 +91,7 @@
 				font-size: 18px !important;
 			}
 		}
+		{{ $css or '' }}
 	</style>
 </head>
 <body bgcolor="#e4e4e4" topmargin="0" leftmargin="0" marginheight="0" marginwidth="0" style="-webkit-font-smoothing: antialiased;width:100% !important;background:#e4e4e4;-webkit-text-size-adjust:none;">

--- a/src/views/templates/widgets.blade.php
+++ b/src/views/templates/widgets.blade.php
@@ -91,6 +91,7 @@
 				font-size: 18px !important;
 			}
 		}
+		
 		{{ $css or '' }}
 	</style>
 </head>


### PR DESCRIPTION
Issue: https://github.com/Snowfire/Beautymail/issues/22

The 'css' key from the configuration wasn't shared across the views so the CSS properties couldn't be used. In order to get this working I did these things:

- Changed the BeautymailServiceProvider in order to add the css array to $beautymail->settings (private property)
- The ServiceProvider checks if the CSS is uncommented and has at least one value
- Changed all 4 templates to include the $css if it is present

I noticed that not all CSS works, I tested with this array:
`'css' => [
        'td.contentblock h4[class=test_header] { color: #FF0000; font-weight: bold; }',
        'table { font-family:\'Helvetica Neue\',Helvetica,Arial,sans-serif; color: #888888; }',
        'table td { font-family:\'Helvetica Neue\',Helvetica,Arial,sans-serif; color: #888888; }',
        'table th { font-family:\'Helvetica Neue\',Helvetica,Arial,sans-serif; color: #888888; font-weight: bold; }',
    ],`

All CSS worked, except the color for my heading which remained #444444, I guess this has something to do with the CssInlinerPlugin, since my CSS wasn't added to the head but inlined in the HTML.