### PR TITLE
Fix issue with artisan if no app key is set

### DIFF
--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -30,7 +30,11 @@ class BeautymailServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../../views', 'beautymail');
 
-        $this->app['mailer']->getSwiftMailer()->registerPlugin(new CssInlinerPlugin());
+        try {
+            $this->app['mailer']->getSwiftMailer()->registerPlugin(new CssInlinerPlugin());
+        } catch (\Exception $e) {
+            \Log::debug('Skipped registering SwiftMailer plugin: CssInlinerPlugin.');
+        }
     }
 
     /**

--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -50,7 +50,7 @@ class BeautymailServiceProvider extends ServiceProvider
                     array_merge(
                         config('beautymail.view'),
                         [
-                            'css' => ! is_null(config('beautymail.css')) && count(config('beautymail.css')) > 0 ? implode(' ', config('beautymail.css')) : '',
+                            'css' => !is_null(config('beautymail.css')) && count(config('beautymail.css')) > 0 ? implode(' ', config('beautymail.css')) : '',
                         ]
                     )
                 );


### PR DESCRIPTION
This will fix an issue where artisan will throw an error if no app key has been set and the Beautymail service provider is already in config/app.php.

Resolves: #57 