### PR TITLE
Implemented logo width and height on minty template and remove alt

### DIFF
--- a/src/views/templates/minty.blade.php
+++ b/src/views/templates/minty.blade.php
@@ -58,7 +58,7 @@
 								<tr>
 									<td valign="middle" width="270" style="padding: 10px 0 10px 20px;" class="logo">
 										<div class="imgpop">
-											<a href="#"><img src="{{ $logo['path'] }}" alt="logo" border="0" style="display:block; border:none; outline:none; text-decoration:none;" st-image="edit" class="logo"></a>
+											<a href="#"><img src="{{ $logo['path'] }}" width="{{ $logo['width'] }}" height="{{ $logo['height'] }}" alt="" border="0" style="display:block; border:none; outline:none; text-decoration:none;" st-image="edit" class="logo"></a>
 										</div>
 									</td>
 								</tr>


### PR DESCRIPTION
Why I removed image alt ?

Because image alt (in this case was "logo") is added at the prefix of email preview.