### PR TITLE
Update minty template log alt and add logo width / height attribute

### DIFF
--- a/src/views/templates/minty.blade.php
+++ b/src/views/templates/minty.blade.php
@@ -58,7 +58,7 @@
 								<tr>
 									<td valign="middle" width="270" style="padding: 10px 0 10px 20px;" class="logo">
 										<div class="imgpop">
-											<a href="#"><img src="{{ array_key_exists('path', $logo) ? $logo['path'] : '' }}" alt="logo" border="0" style="display:block; border:none; outline:none; text-decoration:none;" st-image="edit" class="logo"></a>
+											<a href="#"><img src="{{ array_key_exists('path', $logo) ? $logo['path'] : '' }}" alt="{{ isset($senderName) ? $senderName : '' }}" width="{{ array_key_exists('width', $logo) ? $logo['width'] : '' }}" height="{{ array_key_exists('height', $logo) ? $logo['height'] : '' }}" border="0" style="display:block; border:none; outline:none; text-decoration:none;" st-image="edit" class="logo"></a>
 										</div>
 									</td>
 								</tr>


### PR DESCRIPTION
When sending an email using the minty template, In the email client preview, a logo text appears in front of all contents. So, I have changed the previous ```alt="logo"``` to ```alt="{{ isset($senderName) ? $senderName : '' }}"``` . 