### PR TITLE
Added PHP 8 Support for L8, L9, L10 and Fix pelago/emogrifier Dependency Error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.*|5.*|^6.0.0|^7.0.0|^8.0.0|^9.0.0",
-        "pelago/emogrifier": "^3.0|^4.0|^5.0|^6.0"
+        "illuminate/support": "4.*|5.*|^6.0.0|^7.0.0|^8.0.0|^9.0.0|^10.0.0",
+        "pelago/emogrifier": "^3.0|^4.0|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
1. Add PHP 8 Support
2. Updated pelago/emogrifier to ^7.0.0
3. Tested in Laravel 8,9,10