### PR TITLE
Add Symfony Mailer CSS inliner plugin

### DIFF
--- a/src/Snowfire/Beautymail/BeautymailServiceProvider.php
+++ b/src/Snowfire/Beautymail/BeautymailServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Snowfire\Beautymail;
 
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class BeautymailServiceProvider extends ServiceProvider
@@ -30,10 +32,14 @@ class BeautymailServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../../views', 'beautymail');
 
-        try {
-            $this->app['mailer']->getSwiftMailer()->registerPlugin(new CssInlinerPlugin());
-        } catch (\Exception $e) {
-            \Log::debug('Skipped registering SwiftMailer plugin: CssInlinerPlugin.');
+        if (version_compare($this->app->version(), '9.0', '>=')) {
+            Event::listen('Illuminate\Mail\Events\MessageSending', 'Snowfire\Beautymail\SymfonyCssInlinerPlugin');
+        } else {
+            try {
+                $this->app['mailer']->getSwiftMailer()->registerPlugin(new SwiftCssInlinerPlugin());
+            } catch (\Exception $e) {
+                \Log::debug('Skipped registering SwiftMailer plugin: CssInlinerPlugin.');
+            }
         }
     }
 

--- a/src/Snowfire/Beautymail/SwiftCssInlinerPlugin.php
+++ b/src/Snowfire/Beautymail/SwiftCssInlinerPlugin.php
@@ -4,7 +4,7 @@ namespace Snowfire\Beautymail;
 
 use Pelago\Emogrifier\CssInliner;
 
-class CssInlinerPlugin implements \Swift_Events_SendListener
+class SwiftCssInlinerPlugin implements \Swift_Events_SendListener
 {
     /**
      * Inline the CSS before an email is sent.

--- a/src/Snowfire/Beautymail/SymfonyCssInlinerPlugin.php
+++ b/src/Snowfire/Beautymail/SymfonyCssInlinerPlugin.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Snowfire\Beautymail;
+
+use Illuminate\Mail\Events\MessageSending;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\Part\AbstractMultipartPart;
+use Symfony\Component\Mime\Part\Multipart\AlternativePart;
+use Symfony\Component\Mime\Part\Multipart\MixedPart;
+use Symfony\Component\Mime\Part\TextPart;
+use Pelago\Emogrifier\CssInliner;
+
+class SymfonyCssInlinerPlugin
+{
+    /**
+     * @param \Illuminate\Mail\Events\MessageSending $event
+     *
+     * @return void
+     */
+    public function handle(MessageSending $event)
+    {
+        $message = $event->message;
+
+        if (!$message instanceof Email) {
+            return;
+        }
+
+        $this->handleSymfonyEmail($message);
+    }
+
+    /**
+     * @param \Symfony\Component\Mime\Email $message
+     *
+     * @return void
+     */
+    private function handleSymfonyEmail(Email $message)
+    {
+        $body = $message->getBody();
+
+        if ($body === null) {
+            return;
+        }
+
+        if ($body instanceof TextPart) {
+            $message->setBody($this->processPart($body));
+        } elseif ($body instanceof AlternativePart || $body instanceof MixedPart) {
+            $partType = get_class($body);
+            $message->setBody(new $partType(
+                ...array_map(
+                    function (AbstractPart $part) {
+                        return $this->processPart($part);
+                    },
+                    $body->getParts()
+                )
+            ));
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\Mime\Part\AbstractPart $part
+     *
+     * @return \Symfony\Component\Mime\Part\AbstractPart
+     */
+    private function processPart(AbstractPart $part)
+    {
+        if ($part instanceof TextPart && $part->getMediaType() === 'text' && $part->getMediaSubtype() === 'html') {
+            return $this->processHtmlTextPart($part);
+        } else if ($part instanceof AbstractMultipartPart) {
+            $partClass = get_class($part);
+            $parts = [];
+
+            foreach ($part->getParts() as $childPart) {
+                $parts[] = $this->processPart($childPart);
+            }
+
+            return new $partClass(...$parts);
+        }
+
+        return $part;
+    }
+
+    /**
+     * @param \Symfony\Component\Mime\Part\TextPart $part
+     *
+     * @return \Symfony\Component\Mime\Part\TextPart
+     */
+    private function processHtmlTextPart(TextPart $part)
+    {
+        return new TextPart(
+            CssInliner::fromHtml($part->getBody())->inlineCss()->render(),
+            $part->getPreparedHeaders()->getHeaderParameter('Content-Type', 'charset') ?: 'utf-8',
+            'html'
+        );
+    }
+}


### PR DESCRIPTION
Laravel switched from Swift Mailer to Symfony Mailer in Laravel 9. As such, the CssInlinerPlugin isn't working and "Skipped registering SwiftMailer plugin: CssInlinerPlugin." is being logged as reported in #72. I've added a new CssInlinerPlugin for Symfony Mailer, based on https://github.com/fedeisas/laravel-mail-css-inliner to fix the CSS inlining in Laravel 9+.